### PR TITLE
Fix conflict with documents app (and maybe other apps)

### DIFF
--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -62,6 +62,7 @@ $mimeTypeDetector = \OC::$server->getMimeTypeDetector();
 $mimeTypeLoader = \OC::$server->getMimeTypeLoader();
 
 // Register custom mimetype we can hook in the frontend
+$mimeTypeDetector->getAllMappings();
 $mimeTypeDetector->registerType('kdbx', 'x-application/kdbx', 'x-application/kdbx');
 
 // And update the filecache for it. TODO: do this on enable only


### PR DESCRIPTION
We found a problem with @azlux on the documents app because of your app.
You register a new mimetype too early and, because of this, the only mime known by the document app is kdbx.
We can't access to the loadMapping() function because it's private, so, we use the getAllMappings() witch call this function instead.