### PR TITLE
Fix mimetype issues with kdbx files

### DIFF
--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -58,12 +58,11 @@ $container->query('OCP\INavigationManager')->add(function () use ($container) {
 	];
 });
 
-$mimeTypeDetector = \OC::$server->getMimeTypeDetector();
 $mimeTypeLoader = \OC::$server->getMimeTypeLoader();
 
-// Register custom mimetype we can hook in the frontend
-$mimeTypeDetector->getAllMappings();
-$mimeTypeDetector->registerType('kdbx', 'x-application/kdbx', 'x-application/kdbx');
+// Changes the mimetype of kdbx files in filecache to correct one
+$mimetypeId = $mimeTypeLoader->getId('x-application/kdbx');
+$mimeTypeLoader->updateFilecache('%.kdbx', $mimetypeId);
 
 // Script for registering file actions
 $eventDispatcher = \OC::$server->getEventDispatcher();


### PR DESCRIPTION
Here is a fix for this issue #34 

I also removed the registration of the mimetype in the app.php file. It seems redundant because the mimetype is also registered when you enable the app. My testing also confirmed this.