### PR TITLE
Bump max nextcloud version to 13

### DIFF
--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -14,7 +14,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/u/mrzyx/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="11" max-version="12" />
+        <nextcloud min-version="11" max-version="13" />
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
Nextcloud 13 beta 3 is already out: https://nextcloud.com/blog/nextcloud-13-beta-3-ready-for-your-testing-go-and-win-a-t-shirt/

see #67