### PR TITLE
Compabilitiy with NC15 (was: NC13) and documentation about mimetype mapping for Keeweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ lines.
 
     "kdbx": ["x-application/kdbx"],
 
-If all other mimetypes are not working properly, just run the
-following command:
+After that, run the following command:
 
     sudo -u www-data php occ files:scan --all
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To update to a new version, simply repeat these steps.
 Unfortunately, apps can't declare new mimetypes on the fly. To make
 Keeweb work properly, you need to add a new mimetype in the
 `mimetypemapping.json` file (also see the Nextcloud manual at
-https://docs.nextcloud.com/server/14/admin_manual/configuration_mimetypes/index.html).
+https://docs.nextcloud.com/server/15/admin_manual/configuration_mimetypes/index.html).
 
 To proceed, create the file `/config/mimetypemapping.json` (in the `config/` folder at
 Nextcloud’s root directory; the file should be stored next to the `config.php`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ This integrates the two with each other. Just click on a \*.kdbx file in Your Ne
 
 To update to a new version, simply repeat these steps.
 
+## Mimetype detection
+
+Unfortunately, apps can't declare new mimetypes on the fly. To make
+Keeweb work properly, you need to add a new mimetype in the
+`mimetypemapping.json` file (at Nextcloud level).
+
+To proceed, just copy `/resources/config/mimetypemapping.dist.json` to
+`/config/mimetypemapping.json` (in the `config/` folder at Nextcloud’s
+root directory; the file should be stored next to the `config.php`
+file). Afterwards add the two following line just after the “_comment”
+lines.
+
+    "kdbx": ["x-application/kdbx"],
+
+If all other mimetypes are not working properly, just run the
+following command:
+
+    sudo -u www-data php occ files:scan --all
+
 ## Development setup
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ Keeweb work properly, you need to add a new mimetype in the
 `mimetypemapping.json` file (also see the Nextcloud manual at
 https://docs.nextcloud.com/server/14/admin_manual/configuration_mimetypes/index.html).
 
-To proceed, just copy `/resources/config/mimetypemapping.dist.json` to
-`/config/mimetypemapping.json` (in the `config/` folder at Nextcloud’s
-root directory; the file should be stored next to the `config.php`
-file). Afterwards add the two following line just after the “_comment”
-lines.
+To proceed, create the file `/config/mimetypemapping.json` (in the `config/` folder at
+Nextcloud’s root directory; the file should be stored next to the `config.php`
+file) or modify the existing one. Make sure, it contains at least the following
+lines:
 
-    "kdbx": ["x-application/kdbx"],
+    {
+    "kdbx": ["x-application/kdbx"]
+    }
 
 After that, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ lines:
     "kdbx": ["x-application/kdbx"]
     }
 
-After that, run the following command:
+After that, run the following command in the root directory of Nextcloud on the server
+(if needed, replace `www-data` with the actual user which is used by the webserver):
 
     sudo -u www-data php occ files:scan --all
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To update to a new version, simply repeat these steps.
 
 Unfortunately, apps can't declare new mimetypes on the fly. To make
 Keeweb work properly, you need to add a new mimetype in the
-`mimetypemapping.json` file (at Nextcloud level).
+`mimetypemapping.json` file (also see the Nextcloud manual at
+https://docs.nextcloud.com/server/14/admin_manual/configuration_mimetypes/index.html).
 
 To proceed, just copy `/resources/config/mimetypemapping.dist.json` to
 `/config/mimetypemapping.json` (in the `config/` folder at Nextcloud’s

--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -14,7 +14,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/u/mrzyx/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="11" max-version="12" />
+        <nextcloud min-version="11" max-version="13" />
     </dependencies>
     <repair-steps>
         <install>

--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -14,7 +14,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/u/mrzyx/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="11" max-version="13" />
+        <nextcloud min-version="11" max-version="14" />
     </dependencies>
     <repair-steps>
         <install>

--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -14,7 +14,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/u/mrzyx/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="11" max-version="14" />
+        <nextcloud min-version="11" max-version="15" />
     </dependencies>
     <repair-steps>
         <install>

--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -43,7 +43,7 @@ class PageController extends Controller {
 		// Override default CSP
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain("'self'");
-		$csp->addAllowedChildSrcDomain("'self'");
+		$csp->addAllowedWorkerSrcDomain("'self'");
 		$response->setContentSecurityPolicy($csp);
 		return $response;
 	}


### PR DESCRIPTION
As discussed in https://github.com/jhass/nextcloud-keeweb/issues/67 this is the description how to add the mimetype mapping for Keeweb to work properly. I tested this in my own Nextcloud ~~13~~ 15 and it works fine (of course with an updated `appinfo/info.xml` to indicate Keeweb as compatible to NC ~~13~~ 15).