### PR TITLE
Fix width on NC14

### DIFF
--- a/keeweb/css/style.css
+++ b/keeweb/css/style.css
@@ -1,5 +1,6 @@
 #app {
   overflow-y: hidden;
+  width: 100%
 }
 
 #app > iframe {


### PR DESCRIPTION
I know that there's still some MIME related issues preventing official NC13 support, but the only other thing that seems to break from NC13 to NC14 is that it renders in a narrow bar on the left. This simple css fix seems to resolve that, and does not appear to break anything on NC13. I do not have an NC12 instance to test on however.