### PR TITLE
Allow favicon.keeweb.info as an image source in CSP

### DIFF
--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -106,6 +106,7 @@ class PageController extends Controller {
 		$csp->addAllowedImageDomain("'self'");
 		$csp->addAllowedImageDomain("data:");
 		$csp->addAllowedImageDomain("blob:");
+		$csp->addAllowedImageDomain("https://favicon.keeweb.info");
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedConnectDomain("'self'");
 		$csp->addAllowedScriptDomain('https://plugins.keeweb.info');


### PR DESCRIPTION
This patch solves a CSP-issue which my Vivaldi's devtool complained when I tried to use favicon-downloader.
I think this is just all to do because this address is currently [hard-coded in original keeweb](https://github.com/keeweb/keeweb/blob/8a47ed864ca11f813ad3c90a5a3ecdc2de9596a3/app/scripts/views/icon-select-view.js#L88).

related: jhass#72, jhass#97