### PR TITLE
blob: for frame-src

### DIFF
--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -100,6 +100,7 @@ class PageController extends Controller {
 		$csp->addAllowedFrameDomain("'self'");
 		$csp->addAllowedFrameDomain("'unsafe-inline'");
 		$csp->addAllowedFrameDomain("'unsafe-eval'");
+		$csp->addAllowedFrameDomain("blob:");
 		$csp->addAllowedStyleDomain("'self'");
 		$csp->addAllowedFontDomain("'self'");
 		$csp->addAllowedFontDomain("data:");


### PR DESCRIPTION
In order to download attachments "blob:" source was added for "frame-src". Without it an error is printed to browser console.