### PR TITLE
load config even if no file should be opened

### DIFF
--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -39,6 +39,8 @@ class PageController extends Controller {
 		$params = ['keeweb' => $this->urlGenerator->linkToRoute('keeweb.page.keeweb')];
 		if (isset($open)) {
 			$params['config'] = 'config?file='.$open;
+		} else {
+			$params['config'] = 'config';
 		}
 		$response = new TemplateResponse("keeweb", "main", $params);
 		// Override default CSP

--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -78,18 +78,17 @@ class PageController extends Controller {
 	public function config($file) {
 		$csrfToken = \OC::$server->getCSRFTokenManager()->getToken()->getEncryptedValue();
 		$webdavBase = \OCP\Util::linkToRemote('webdav');
-		$config = [
-			'settings' => (object) null,
-			'files' => [
+		$config = ['settings' => (object) null];
+		if (isset($file)) {
+			$config['files'] = [
 				[
 					'storage' => 'webdav',
 					'name' => $file.' on '.$this->request->getServerHost(),
 					'path' => $this->joinPaths($webdavBase, $file.'?requesttoken='.urlencode($csrfToken)),
 					"options" => ['user' => null, 'password' => null]
 				]
-			]
-		];
-
+			];
+		}	
 		return new JSONResponse($config);
 	}
 


### PR DESCRIPTION
A custom default config specified in the pagecontroller did not load if one opens the Keeweb-App without a file.

related #70 