### PR TITLE
implement setting locale from nextcloud

### DIFF
--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -81,18 +81,17 @@ class PageController extends Controller {
 	public function config($file) {
 		$csrfToken = \OC::$server->getCSRFTokenManager()->getToken()->getEncryptedValue();
 		$webdavBase = \OCP\Util::linkToRemote('webdav');
-		$config = [
-			'settings' => [ 'locale' => str_replace('_', '-', $this->l10nFactory->findLocale()) ],
-			'files' => [
+		$config = ['settings' => ['locale' =>  str_replace('_', '-', $this->l10nFactory->findLocale())]];
+		if (isset($file)) {
+			$config['files'] = [
 				[
 					'storage' => 'webdav',
 					'name' => $file.' on '.$this->request->getServerHost(),
 					'path' => $this->joinPaths($webdavBase, $file.'?requesttoken='.urlencode($csrfToken)),
 					"options" => ['user' => null, 'password' => null]
 				]
-			]
-		];
-
+			];
+		}
 		return new JSONResponse($config);
 	}
 

--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -13,6 +13,7 @@ namespace OCA\Keeweb\Controller;
 
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use \OCP\IConfig;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
@@ -24,11 +25,13 @@ class PageController extends Controller {
 
 	private $urlGenerator;
 	private $settings;
+	private $l10nFactory;	
 
-	public function __construct($AppName, IRequest $request, IURLGenerator $urlGenerator, IConfig $settings) {
+	public function __construct($AppName, IRequest $request, IURLGenerator $urlGenerator, IConfig $settings, IFactory $l10nFactory) {
 		parent::__construct($AppName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->settings = $settings;
+		$this->l10nFactory = $l10nFactory;		
 	}
 
 	/**
@@ -39,6 +42,8 @@ class PageController extends Controller {
 		$params = ['keeweb' => $this->urlGenerator->linkToRoute('keeweb.page.keeweb')];
 		if (isset($open)) {
 			$params['config'] = 'config?file='.$open;
+		} else {
+			$params['config'] = 'config';
 		}
 		$response = new TemplateResponse("keeweb", "main", $params);
 		// Override default CSP
@@ -77,7 +82,7 @@ class PageController extends Controller {
 		$csrfToken = \OC::$server->getCSRFTokenManager()->getToken()->getEncryptedValue();
 		$webdavBase = \OCP\Util::linkToRemote('webdav');
 		$config = [
-			'settings' => (object) null,
+			'settings' => [ 'locale' => str_replace('_', '-', $this->l10nFactory->findLocale()) ],
 			'files' => [
 				[
 					'storage' => 'webdav',


### PR DESCRIPTION
gets language setting from Nextcloud
As Nextcloud uses underscores in locale but keeweb expects dashs (e.g. de-DE), those are replaced.

Also contains change from #121 

This might not be the best implementation as I only have little experience with Nextcloud but it is working for me and is probably a great benefit for most users of the app.