### PR TITLE
Register application/x-kdbx the right way

### DIFF
--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -59,9 +59,6 @@ $container->query('OCP\INavigationManager')->add(function () use ($container) {
 });
 
 $mimeTypeDetector = \OC::$server->getMimeTypeDetector();
-
-// Register custom mimetype we can hook in the frontend
-$mimeTypeDetector->getAllMappings();
 $mimeTypeDetector->registerType('kdbx', 'application/x-kdbx', 'application/x-kdbx');
 
 // Script for registering file actions

--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -14,6 +14,14 @@ namespace OCA\Keeweb\AppInfo;
 use OCP\AppFramework\App;
 use OCA\Keeweb\Controller\PageController;
 
+$mimeTypeDetector = \OC::$server->getMimeTypeDetector();
+$mimeTypeDetector->registerType('kdbx', 'application/x-kdbx', 'application/x-kdbx');
+
+if (\OC::$REQUESTEDAPP === 'dav') {
+    /** For dav requests it should be enough to register the mime type and skip the rest of the app initialization. */
+    return;
+}
+
 require_once __DIR__ . '/autoload.php';
 
 class Application extends App {
@@ -57,9 +65,6 @@ $container->query('OCP\INavigationManager')->add(function () use ($container) {
 		'name' => $l10n->t('Keeweb'),
 	];
 });
-
-$mimeTypeDetector = \OC::$server->getMimeTypeDetector();
-$mimeTypeDetector->registerType('kdbx', 'application/x-kdbx', 'application/x-kdbx');
 
 // Script for registering file actions
 $eventDispatcher = \OC::$server->getEventDispatcher();

--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -59,7 +59,6 @@ $container->query('OCP\INavigationManager')->add(function () use ($container) {
 });
 
 $mimeTypeDetector = \OC::$server->getMimeTypeDetector();
-$mimeTypeLoader = \OC::$server->getMimeTypeLoader();
 
 // Register custom mimetype we can hook in the frontend
 $mimeTypeDetector->getAllMappings();

--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -11,11 +11,16 @@
 
 namespace OCA\Keeweb\AppInfo;
 
+use OC\Files\Type\Detection;
 use OCP\AppFramework\App;
 use OCA\Keeweb\Controller\PageController;
 
 $mimeTypeDetector = \OC::$server->getMimeTypeDetector();
-$mimeTypeDetector->registerType('kdbx', 'application/x-kdbx', 'application/x-kdbx');
+if ($mimeTypeDetector instanceof Detection) {
+    /** registerType without getAllMappings will prevent loading nextcloud's default mappings. */
+    $mimeTypeDetector->getAllMappings();
+    $mimeTypeDetector->registerType('kdbx', 'application/x-kdbx', 'application/x-kdbx');
+}
 
 if (\OC::$REQUESTEDAPP === 'dav') {
     /** For dav requests it should be enough to register the mime type and skip the rest of the app initialization. */

--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -10,6 +10,9 @@ Please read https://github.com/jhass/nextcloud-keeweb/blob/master/README.md#mime
     <licence>agpl</licence>
     <author>Jonne Haß</author>
     <namespace>Keeweb</namespace>
+    <types>
+        <filesystem/>
+    </types>
     <category>tools</category>
     <category>integration</category>
     <website>https://github.com/jhass/nextcloud-keeweb</website>

--- a/keeweb/lib/Migration/AddMimetypeToFilecache.php
+++ b/keeweb/lib/Migration/AddMimetypeToFilecache.php
@@ -2,29 +2,26 @@
 
 namespace OCA\Keeweb\Migration;
 
-use OCP\Migration\IRepairStep;
-use OCP\IDBConnection;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 class AddMimetypeToFilecache implements IRepairStep {
-  public function __construct(IDBConnection $connection) {}
 
-  public function getName() {
-    return "Add custom mimetype to filecache";
-  }
+    private $mimeTypeLoader;
 
-  public function run(IOutput $output) {
-    $mimeTypeDetector = \OC::$server->getMimeTypeDetector();
-    $mimeTypeLoader = \OC::$server->getMimeTypeLoader();
+    public function __construct(IMimeTypeLoader $mimeTypeLoader) {
+        $this->mimeTypeLoader = $mimeTypeLoader;
+    }
 
-    // Register custom mimetype
-    $mimeTypeDetector->getAllMappings();
-    $mimeTypeDetector->registerType('kdbx', 'x-application/kdbx', 'x-application/kdbx');
+    public function getName() {
+        return 'Add custom mimetype to filecache';
+    }
 
-    // And update the filecache for it.
-    $mimetypeId = $mimeTypeLoader->getId('x-application/kdbx');
-    $mimeTypeLoader->updateFilecache('%.kdbx', $mimetypeId);
-
-    $output->info("Added custom mimetype to filecache.");
-  }
+    public function run(IOutput $output) {
+        // And update the filecache for it.
+        $mimetypeId = $this->mimeTypeLoader->getId('application/x-kdbx');
+        $this->mimeTypeLoader->updateFilecache('kdbx', $mimetypeId);
+        $output->info('Added custom mimetype to filecache.');
+    }
 }

--- a/keeweb/lib/Migration/RemoveMimetypeFromFilecache.php
+++ b/keeweb/lib/Migration/RemoveMimetypeFromFilecache.php
@@ -2,21 +2,25 @@
 
 namespace OCA\Keeweb\Migration;
 
-use OCP\Migration\IRepairStep;
-use OCP\IDBConnection;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
 class RemoveMimetypeFromFilecache implements IRepairStep {
-  public function __construct(IDBConnection $connection) {}
 
-  public function getName() {
-    return "Remove custom mimetype from filecache";
-  }
+    private $mimeTypeLoader;
 
-  public function run(IOutput $output) {
-      $mimeTypeLoader = \OC::$server->getMimeTypeLoader();
-      $mimetypeId = $mimeTypeLoader->getId('application/octet-stream');
-      $mimeTypeLoader->updateFilecache('%.kdbx', $mimetypeId);
-      $output->info("Removed custom mimetype from filecache.");
-  }
+    public function __construct(IMimeTypeLoader $mimeTypeLoader) {
+        $this->mimeTypeLoader = $mimeTypeLoader;
+    }
+
+    public function getName() {
+        return 'Remove custom mimetype from filecache';
+    }
+
+    public function run(IOutput $output) {
+        $mimetypeId = $this->mimeTypeLoader->getId('application/octet-stream');
+        $this->mimeTypeLoader->updateFilecache('kdbx', $mimetypeId);
+        $output->info('Removed custom mimetype from filecache.');
+    }
 }


### PR DESCRIPTION
Hi @jhass,

Thanks for your app :+1: Some people at nextcloud/server (e.g. https://github.com/nextcloud/server/issues/17217) and also over here are reporting issues. `*.kdbx` files are not opened with the app :disappointed: 

This pull request should fix most of these issues and also make the manual changes to `mimetypemapping.json` superfluous (at least on my setup).

I'm not a heavy user of keeweb. We probably need some testers ;)


