### PR TITLE
Comply with NC 19 to query App

### DIFF
--- a/keeweb/appinfo/app.php
+++ b/keeweb/appinfo/app.php
@@ -44,7 +44,7 @@ class Application extends App {
     }
 }
 
-$app = new Application();
+$app = \OC::$server->query(Application::class);
 $container = $app->getContainer();
 
 $container->query('OCP\INavigationManager')->add(function () use ($container) {


### PR DESCRIPTION
Prevent RuntimeException `App class OCA\\Keeweb\\AppInfo\\Application is not setup via query() but directly`
See https://docs.nextcloud.com/server/19/developer_manual/app/upgrade-guide.html#back-end-changes