### PR TITLE
fix documentation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This integrates the two with each other. Just click on a \*.kdbx file in Your Ne
 ## Install
 
 1. Go to the releases page, download the latest version.
-1. Extract it to `your_nextcloud/apps`, for example with `tar xvf keeweb-0.6.3.tar.gz -C /path/to/your/nextcloud/apps`.
+1. Extract it to `your_nextcloud/custom_apps`, for example with `tar xvf keeweb-0.6.3.tar.gz -C /path/to/your/nextcloud/custom_apps`.
 1. Go to "Apps" and then "Not enabled", scroll down to "Experimental" and enable it.
 
 To update to a new version, simply repeat these steps.


### PR DESCRIPTION
should be custom_apps as normal apps folder would install as system app (resulting in a temporary maintenance mode for the upgrade)