### PR TITLE
Update compatibility information for NC24

### DIFF
--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -15,7 +15,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="16" max-version="23" />
+        <nextcloud min-version="16" max-version="24" />
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
Since Keeweb also works in NC24, we can change the supported version information.