### PR TITLE
Change favicon-downloader domain

### DIFF
--- a/keeweb/controller/pagecontroller.php
+++ b/keeweb/controller/pagecontroller.php
@@ -131,9 +131,10 @@ class PageController extends Controller {
 		$csp->addAllowedImageDomain("'self'");
 		$csp->addAllowedImageDomain("data:");
 		$csp->addAllowedImageDomain("blob:");
-		$csp->addAllowedImageDomain("https://favicon.keeweb.info");
+		$csp->addAllowedImageDomain('https://services.keeweb.info');
 		$csp->addAllowedScriptDomain("'self'");
 		$csp->addAllowedConnectDomain("'self'");
+		$csp->addAllowedConnectDomain('https://services.keeweb.info');
 		$csp->addAllowedScriptDomain('https://plugins.keeweb.info');
 		$csp->addAllowedConnectDomain('https://plugins.keeweb.info');
 		$csp->addAllowedChildSrcDomain("blob:");


### PR DESCRIPTION
from `https://favicon.keeweb.info` to `https://services.keeweb.info`, adapts nextcloud-keeweb to keeweb/keeweb@00d7ff6
And add the domain as `AllowedConnectDomain`, as CORS required.