### PR TITLE
Update info.xml for NC 25 compatibility

### DIFF
--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -15,7 +15,7 @@
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://cloud.aeshna.de/keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="16" max-version="24" />
+        <nextcloud min-version="16" max-version="25" />
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
No app breaking changes made according to [app maintenance guide](https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_25.html) and tested on my NC 25 instance running Ubuntu 20.04.