### PR TITLE
Follow up to PSR-4 migration: App.php to application migration

### DIFF
--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -25,4 +25,13 @@
             <step>OCA\Keeweb\Migration\UnregisterMimeType</step>
         </uninstall>
     </repair-steps>
+    <navigations>
+        <navigation>
+            <id>keeweb</id>
+            <order>2</order>
+            <route>keeweb.page.index</route>
+            <icon>app.svg</icon>
+            <name>Keeweb</name>
+        </navigation>
+    </navigations>
 </info>

--- a/keeweb/lib/AppInfo/Application.php
+++ b/keeweb/lib/AppInfo/Application.php
@@ -30,33 +30,6 @@ class Application extends App {
     }
 }
 
-$app = \OC::$server->query(Application::class);
-$container = $app->getContainer();
-
-$container->query('OCP\INavigationManager')->add(function () use ($container) {
-	$urlGenerator = $container->query('OCP\IURLGenerator');
-	$l10n = $container->query('OCP\IL10N');
-	return [
-		// the string under which your app will be referenced in Nextcloud
-		'id' => 'keeweb',
-
-		// sorting weight for the navigation. The higher the number, the higher
-		// will it be listed in the navigation
-		'order' => 2,
-
-		// the route that will be shown on startup
-		'href' => $urlGenerator->linkToRoute('keeweb.page.index'),
-
-		// the icon that will be shown in the navigation
-		// this file needs to exist in img/
-		'icon' => $urlGenerator->imagePath('keeweb', 'app.svg'),
-
-		// the title of your application. This will be used in the
-		// navigation or on the settings page of your app
-		'name' => $l10n->t('Keeweb'),
-	];
-});
-
 // Script for registering file actions
 $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(

--- a/keeweb/lib/AppInfo/Application.php
+++ b/keeweb/lib/AppInfo/Application.php
@@ -11,15 +11,22 @@
 
 namespace OCA\Keeweb\AppInfo;
 
-use OC\Files\Type\Detection;
-use OCP\AppFramework\App;
 use OCA\Keeweb\Controller\PageController;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Util;
+use Psr\Container\ContainerInterface;
 
-class Application extends App {
- public function __construct(array $urlParams=array()){
-        parent::__construct('keeweb', $urlParams);
-        $container = $this->getContainer();
-        $container->registerService('PageController', function($c) {
+class Application extends App implements IBootstrap {
+    public function __construct(){
+        parent::__construct('keeweb');
+    }
+
+    public function register(IRegistrationContext $context): void {
+        $context->registerService('PageController', function (ContainerInterface $c) {
             return new PageController(
                 $c->query('AppName'),
                 $c->query('Request'),
@@ -28,13 +35,15 @@ class Application extends App {
             );
         });
     }
-}
 
-// Script for registering file actions
-$eventDispatcher = \OC::$server->getEventDispatcher();
-$eventDispatcher->addListener(
-	'OCA\Files::loadAdditionalScripts',
-	function() {
-		\OCP\Util::addScript('keeweb', 'viewer');
-	}
-);
+    public function boot(IBootContext $context): void {
+        $context->injectFn(function (IEventDispatcher $eventDispatcher) {
+            $eventDispatcher->addListener(
+                'OCA\Files::loadAdditionalScripts',
+                function() {
+                    Util::addScript('keeweb', 'viewer');
+                }
+            );
+        });
+    }
+}

--- a/keeweb/tests/bootstrap.php
+++ b/keeweb/tests/bootstrap.php
@@ -10,4 +10,3 @@
  */
 
 require_once __DIR__ . '/../../../tests/bootstrap.php';
-require_once __DIR__ . '/../appinfo/autoload.php';


### PR DESCRIPTION
I noticed that one of the files I moved in #222 was the `app.php` which contains the class `Application`. I took a look at the documentation at https://docs.nextcloud.com/server/latest/developer_manual/app_development/bootstrap.html which says that the `app.php` is deprecated and I think the code inside should be adjusted as well.

I used said documentation and also took a look at different applications under https://github.com/nextcloud e.g.
- register event listener: https://github.com/nextcloud/server/blob/81bb3362b24a621fb399877739e7bff35ec13eb7/apps/systemtags/lib/AppInfo/Application.php#LL49C1-L49C1
- navigation entry:
  - https://docs.nextcloud.com/server/latest/developer_manual/app_development/info.html
  - https://github.com/nextcloud/contacts/blob/main/appinfo/info.xml#L53

I deactivated and removed keeweb from my instance, built keeweb as described in README, uploaded, extracted and activated it and it still works for me and I don't get any log entries on debug loglevel.

Related to https://github.com/jhass/nextcloud-keeweb/issues/219 (works for me without issues, so this time the issue might be resolved for real)