### PR TITLE
Update version info for Nextcloud 31

### DIFF
--- a/keeweb/appinfo/info.xml
+++ b/keeweb/appinfo/info.xml
@@ -7,9 +7,9 @@
     <description>
 Open Keepass stores inside Nextcloud with Keeweb just by clicking on an *.kdbx file in your Nextcloud.
         
-WARNING: As of July 2024 KeeWeb itself did not get any new release since 2021 and may contain security issues. You may consider to choose an actively maintained developed app like Passman or Passwords. If this changes in the future, this notice will be updated accordingly.
+WARNING: As of March 2025 KeeWeb itself did not get any new release since 2021 and may contain security issues. You may consider to choose an actively maintained developed app like Passman or Passwords. If this changes in the future, this notice will be updated accordingly.
     </description>
-    <version>0.6.20</version>
+    <version>0.6.21</version>
     <licence>agpl</licence>
     <author>Jonne Haß, Arno Welzel, Florian Forestier</author>
     <namespace>Keeweb</namespace>
@@ -20,7 +20,7 @@ WARNING: As of July 2024 KeeWeb itself did not get any new release since 2021 an
     <repository>https://github.com/jhass/nextcloud-keeweb</repository>
     <screenshot>https://arnowelzel.de/download/nextcloud-keeweb.gif</screenshot>
     <dependencies>
-        <nextcloud min-version="28" max-version="30"/>
+        <nextcloud min-version="28" max-version="31"/>
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
Since Keeweb works fine with NC 31 as well, we can just update the supported version information.