### PR TITLE
Fix viewer.js loading with Nextcloud 34 bootstrap

### DIFF
--- a/keeweb/lib/AppInfo/Application.php
+++ b/keeweb/lib/AppInfo/Application.php
@@ -13,35 +13,32 @@ declare(strict_types=1);
 
 namespace OCA\Keeweb\AppInfo;
 
+use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\Keeweb\Listener\LoadAdditionalScriptsListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Files\IMimeTypeDetector;
-use OCP\IRequest;
-use OCP\Util;
 
 class Application extends App implements IBootstrap {
     public const APP_ID = 'keeweb';
 
-    public function __construct() {
-        parent::__construct(self::APP_ID);
+    public function __construct(array $urlParams = []) {
+        parent::__construct(self::APP_ID, $urlParams);
     }
 
     public function register(IRegistrationContext $context): void {
-        // Controllers are auto-wired by the AppFramework, no manual
-        // service registration needed.
+        $context->registerEventListener(
+            LoadAdditionalScriptsEvent::class,
+            LoadAdditionalScriptsListener::class
+        );
     }
 
     public function boot(IBootContext $context): void {
-        $context->injectFn(function (IMimeTypeDetector $detector, IRequest $request): void {
+        $context->injectFn(function (IMimeTypeDetector $detector): void {
             $detector->getAllMappings();
             $detector->registerType('kdbx', 'application/x-kdbx');
-
-            $url = $request->getRequestUri();
-            if ($url !== '' && (preg_match('%/apps/files(/.*)?%', $url) || str_contains($url, '/s/'))) {
-                Util::addScript(self::APP_ID, 'viewer');
-            }
         });
     }
 }

--- a/keeweb/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/keeweb/lib/Listener/LoadAdditionalScriptsListener.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\Keeweb\Listener;
+
+use OCA\Keeweb\AppInfo\Application;
+use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class LoadAdditionalScriptsListener implements IEventListener {
+    public function handle(Event $event): void {
+        if (!$event instanceof LoadAdditionalScriptsEvent) {
+            return;
+        }
+
+        Util::addScript(Application::APP_ID, 'viewer');
+    }
+}


### PR DESCRIPTION
Fix Keeweb viewer loading on Nextcloud 34.

The previous implementation used `Util::addScript()` from
`Application::boot()` based on the current request URI.

With Nextcloud 34, this does not reliably load `viewer.js` in the Files
interface.

This change registers a listener for
`OCA\Files\Event\LoadAdditionalScriptsEvent` and loads the Keeweb
viewer script when the Files application is initialized.

## Testing

Tested with:

- Nextcloud 34
- Keeweb 0.6.27
- PHP 8.1+

Opening a `.kdbx` file from the Files interface now correctly loads
`/apps/keeweb/js/viewer.js` and the Keeweb viewer works as expected.